### PR TITLE
Retrieve activity granularity

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -123,7 +123,7 @@ groucho.config = {
 To write your own features, grab browsing history and work with it. You'll need to use a little structure to define the condition, in this case: the name of the tracking group...
 
 ```javascript
-$.each(groucho.getActivities(), function (key, record) {
+$.each(groucho.getActivities({'group' : 'browsing'}), function (key, record) {
   someComparison(record.property, record.url);
 });
 ```
@@ -306,10 +306,8 @@ You can work directly with tracking activites and create your own smart function
 function recentVideos(timeframe, category) {
   var query = {
         'group' : 'watch',
-        'conditions' : [
-          'property' : 'type',
-          'values' : category
-        ]
+        'property' : 'type',
+        'values' : [category]
       },
       myActivities = groucho.getActivities(query),
       now = new Date().getTime(),

--- a/DOCS.md
+++ b/DOCS.md
@@ -123,7 +123,7 @@ groucho.config = {
 To write your own features, grab browsing history and work with it. You'll need to use a little structure to define the condition, in this case: the name of the tracking group...
 
 ```javascript
-$.each(groucho.getActivities({'group' : 'browsing'}), function (key, record) {
+$.each(groucho.getActivities('browsing'), function (key, record) {
   someComparison(record.property, record.url);
 });
 ```
@@ -282,8 +282,7 @@ $('.videos a.play').bind('click', function() {
 They will be stored as key/value in jStorage. But can be returned as an array, filtered down to the group specified. Remember to structure the condition.
 
 ```javascript
-var condition = {'group' : 'watch'},
-    myActivities = groucho.getActivities(condition);
+var myActivities = groucho.getActivities('watch');
 ```
 
 ```json
@@ -304,28 +303,26 @@ You can work directly with tracking activites and create your own smart function
 
 ```javascript
 function recentVideos(timeframe, category) {
-  var query = {
-        'group' : 'watch',
-        'property' : 'type',
-        'values' : [category]
-      },
-      myActivities = groucho.getActivities(query),
+  var conditions = [{'type' : [category]}],
+      activityList = groucho.getActivities('watch', conditions),
       now = new Date().getTime(),
-      recentList,
+      recentList = [],
       timestamp;
 
-  for (var i in myActivities) {
-    timestamp = myActivities[i]._key.split('.')[2]);
+  for (var i in activityList) {
+    timestamp = activityList[i]._key.split('.')[2]);
     if (timestamp > (now - timeframe)) {
-      returnRecent.push({
-        'videoTitle' : myActivities[i].videoTitle,
-        'url' : myActivities[i].url
+      recentList.push({
+        'videoTitle' : activityList[i].videoTitle,
+        'url' : activityList[i].url
       });
     }
   }
+
+  return recentList;
 }
 
-$.each(recentVideos(604800, ['tutorial']), function() {
+$.each(recentVideos(604800, 'tutorial'), function() {
   newItem = '<li><a href="' + this.url + '">' + this.videoTitle + '</a></li>';
   $('ul.recentlyWatched').append(newItem);
 });

--- a/DOCS.md
+++ b/DOCS.md
@@ -119,10 +119,11 @@ groucho.config = {
   ]
 }
 ```
-To write your own features, grab browsing history and work with it like this...
+
+To write your own features, grab browsing history and work with it. You'll need to use a little structure to define the condition, in this case: the name of the tracking group...
 
 ```javascript
-$.each(groucho.getActivities('browsing'), function (key, record) {
+$.each(groucho.getActivities(), function (key, record) {
   someComparison(record.property, record.url);
 });
 ```
@@ -270,45 +271,70 @@ var favCategoryTerms = groucho.getFavoriteTerms('*', false, 7);
 You can register your own tracking activities like this...
 
 ```javascript
-// Track your own activities.
-$('.my-special-links').bind('click', function (e) {
-  myObj.linkText = $(this).text()
-  myObj.myProperty = $(this).attr('data-property');
-  groucho.createActivity('my_activity', myObj);
+$('.videos a.play').bind('click', function() {
+  groucho.createActivity('watch', {
+    'videoId' : $(this).data('videoId'),
+    'category' : $(this).data('category'),
+    'videoTitle' : $(this).text()
+  });
 });
 ```
-They will be stored as key/value in jStorage. But can be returned as an array, filtered down to the group specified.
+They will be stored as key/value in jStorage. But can be returned as an array, filtered down to the group specified. Remember to structure the condition.
 
 ```javascript
-var myActivities = groucho.getActivities('my_activity');
+var condition = {'group' : 'watch'},
+    myActivities = groucho.getActivities(condition);
 ```
+
 ```json
 [{
-  "_key" : "track.my_activity.398649600",
-  "linkText" : "Link text from page",
-  "myProperty" : "the-property-value"
+  "_key" : "track.watch.398649600",
+  "videoId" : 456,
+  "category" : "tutorial",
+  "videoTitle" : "Learn About Something"
 }, {
-  "_key" : "track.my_activity.398649999",
-  "linkText" : "Other link text",
-  "myProperty" : "this-property-value"
+  "_key" : "track.watch.398649999",
+  "videoId" : 789,
+  "category" : "fun",
+  "videoTitle" : "Be Entertained"
 }]
 ```
-You can work directly with tracking activites and create your own smart functions...
+You can work directly with tracking activites and create your own smart functions. This example finds tutorial videos watched in the last week...
+
 
 ```javascript
-function myActivitySmarts () {
-  var myActivities = groucho.getActivities('my_activity'),
-      record;
+function recentVideos(timeframe, category) {
+  var query = {
+        'group' : 'watch',
+        'conditions' : [
+          'property' : 'type',
+          'values' : category
+        ]
+      },
+      myActivities = groucho.getActivities(query),
+      now = new Date().getTime(),
+      recentList,
+      timestamp;
 
-  for (i in myActivities) {
-    record = myActivities[i];
-    if (myComparison(record.property, record.url, record._key.split('.')[2])) {
-      count++;
+  for (var i in myActivities) {
+    timestamp = myActivities[i]._key.split('.')[2]);
+    if (timestamp > (now - timeframe)) {
+      returnRecent.push({
+        'videoTitle' : myActivities[i].videoTitle,
+        'url' : myActivities[i].url
+      });
     }
   }
-  return count;
 }
+
+$.each(recentVideos(604800, ['tutorial']), function() {
+  newItem = '<li><a href="' + this.url + '">' + this.videoTitle + '</a></li>';
+  $('ul.recentlyWatched').append(newItem);
+});
 ```
+_...but you shouldn't insert HTML this way._
+
+
 
 ### Local Storage
 This library uses in-browser key/value localStorage with the convenient jStorage abstraction library. If you're new to localStorage, it's no big deal and is a new tool we should all be using.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ if (groucho.favoriteTerms.hasOwnProperty(taxonomy)) {
 
 Use page view activity tracking to dig through history and alter UX.
 ```javascript
-var history = groucho.getActivities({'group' : 'browsing'}),
+var history = groucho.getActivities('browsing'),
     links = $('a.promoted'),
     count = 0;
 
@@ -126,7 +126,7 @@ $('.videos a.play').bind('click', function() {
 
 Retrieve activities later to personalize pages. Example swaps in the last watched video...
 ```javascript
-var history = groucho.getActivities({'group' : 'watch'});
+var history = groucho.getActivities('watch');
 
 if (history.length) {
   $.get("videos.json?id=" + history[0].videoId, function(data) {

--- a/README.md
+++ b/README.md
@@ -100,11 +100,11 @@ if (groucho.favoriteTerms.hasOwnProperty(taxonomy)) {
 ### Pageview Tracking
 
 Use page view activity tracking to dig through history and alter UX.
-
 ```javascript
-var history = groucho.getActivities('browsing'),
+var history = groucho.getActivities(),
     links = $('a.promoted'),
     count = 0;
+
 for (var i in history) {
   // Determine if they've seen a page with a specific property.
   if (history[i].hasOwnProperty('myProperty') count++;
@@ -114,37 +114,32 @@ if (count < 2) links.addClass('featured');
 else if (count >= 2 && count < 7) links.addClass('reduced');
 else links.addClass('hidden');
 ```
-Show the last viewed item of a given type. Example is last watched video...
-
-```javascript
-var history = groucho.getActivities('watch');
-if (history.length) {
-  $.get("videos.json?id=" + history[0].videoId, function(data) {
-    $('.recent').html(displayVideo(data));
-  });
-}
-```
 
 ## Custom Activies
 
 Register your own tracking activities like this...
-
 ```javascript
-// Track your own activities.
-$('.my-special-links').bind('click', function (e) {
-  groucho.createActivity('my_activity', {
-    'linkText' : $(this).text(),
-    'myProperty' : $(this).attr('data-property')
-  });
+$('.videos a.play').bind('click', function() {
+  groucho.createActivity('watch', {'videoId' : 789});
 });
-// Later...
-myActivites = groucho.getActivities('my_activity');
+```
+
+Retrieve activities later to personalize pages. Example swaps in the last watched video...
+```javascript
+var history = groucho.getActivities({'group' : 'watch'});
+
+if (history.length) {
+  $.get("videos.json?id=" + history[0].videoId, function(data) {
+    $('.recent').find('.title').text(data.title)
+      .find('.graphic').text(data.graphic)
+      .find('a').attr('href', data.url);
+  });
+}
 ```
 
 ### Basic User Info
 
 Wait for data availability and user basic user info.
-
 ```javascript
 (function ($) {
   $(document).ready(function(){

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ if (groucho.favoriteTerms.hasOwnProperty(taxonomy)) {
 
 Use page view activity tracking to dig through history and alter UX.
 ```javascript
-var history = groucho.getActivities(),
+var history = groucho.getActivities({'group' : 'browsing'}),
     links = $('a.promoted'),
     count = 0;
 

--- a/groucho.json
+++ b/groucho.json
@@ -2,7 +2,7 @@
   "name": "groucho",
   "title": "Groucho",
   "description": "Know more about your anonymous users. In-browser storage tracking tool.",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "homepage": "https://github.com/tableau-mkt/groucho",
   "author": {
     "name": "Josh Lind",

--- a/test/groucho_test.js
+++ b/test/groucho_test.js
@@ -159,7 +159,7 @@
   });
 
   //@todo Confirm granular activity request work.
-  test('Activity retrieval', function() {
+  test('Activity retrieval', 0, function() {
 
 /*
 

--- a/test/groucho_test.js
+++ b/test/groucho_test.js
@@ -161,6 +161,65 @@
   //@todo Confirm granular activity request work.
   test('Activity retrieval', 0, function() {
 
+    // Mock functions.
+    var counters = {
+      'checkProperties': 0,
+      'checkValues': 0,
+      'addRecord': 0
+    };
+    groucho.getActivities.checkProperties = function() {
+      counters[this.name]++
+    };
+    groucho.getActivities.checkValues = function() {
+      counters[this.name]++
+    };
+    groucho.getActivities.addRecord = function() {
+      counters[this.name]++
+    };
+
+    // Create activities!
+    groucho.createActivity('testThingy', {
+      'neato' : 'definately',
+      'yep' : 'probably'
+    });
+    groucho.createActivity('testStuff', {
+      'neato' : 'definately',
+      'yep' : 'probably'
+    });
+    groucho.createActivity('testThingy', {
+      'neato' : 'unclear'
+    });
+    groucho.createActivity('testThingy', {
+      'wow' : 'indeed',
+      'yep' : 'probably'
+    });
+
+    // Tests...
+    groucho.getActivities('testThingy');
+
+    groucho.getActivities('testStuff');
+
+    groucho.getActivities('testThingy', [
+      {'neato' : ['definately']}
+    ]);
+
+    groucho.getActivities('testThingy', [
+      {'neato' : ['definately', 'unclear']}
+    ]);
+
+    groucho.getActivities('testThingy', [
+      {'neato' : ['definately']},
+      {'wow' : ['indeed']}
+    ]);
+
+    groucho.createActivity('testStuff', [
+      {'neato' : ['unclear']},
+      {'neato' : ['definately']}
+    ]);
+
+
+
+
 /*
 
     groucho.getActivities();

--- a/test/groucho_test.js
+++ b/test/groucho_test.js
@@ -84,7 +84,7 @@
   });
 
   test('Pageview activities', function() {
-    var myResults = groucho.getActivities({'group' : 'browsing'}),
+    var myResults = groucho.getActivities('browsing'),
         fakeData = { 'meainingLess': 'info' },
         timeout = 0;
 
@@ -110,7 +110,7 @@
     history.pushState('', 'New Page Title', window.location + '#another-page');
     // Manually create another browsing record.
     groucho.trackHit();
-    myResults = groucho.getActivities({'group' : 'browsing'});
+    myResults = groucho.getActivities('browsing');
     strictEqual(
       myResults.length,
       2,
@@ -137,7 +137,7 @@
     setTimeout(function () {
 
       strictEqual(
-        groucho.getActivities({'group' : 'fake_thing'}).length,
+        groucho.getActivities('fake_thing').length,
         groucho.config.trackExtent,
         'Tracking activities are kept within the configured extent'
       );
@@ -165,48 +165,52 @@
 
     groucho.getActivities();
 
-    groucho.getActivities({
-      'group' : 'fake_thing',
+    groucho.getActivities('fake_thing');
+
+    groucho.getActivities('wrong');
+
+    groucho.getActivities(
+      'fake_thing',
+      [{'entityBundle'}]
     });
 
     groucho.getActivities({
-      'group' : 'wrong',
+      'fake_thing',
+      [{'entityBundle' : 'article'}]
     });
 
     groucho.getActivities({
-      'group' : 'fake_thing',
-      'property' : 'entityBundle'
+      'fake_thing',
+      [{entityBundle' : ['article']}]
     });
 
     groucho.getActivities({
-      'group' : 'fake_thing',
-      'value' : ['article']
+      'fake_thing',
+      [{'entityBundle' : ['wrong', 'article']}}
     });
 
     groucho.getActivities({
-      'group' : 'fake_thing',
-      'property' : 'entityBundle',
-      'value' : 'article'
+      'fake_thing',
+      ['entityBundle' : ['wrong']}]
     });
 
     groucho.getActivities({
-      'group' : 'fake_thing',
-      'property' : 'entityBundle',
-      'value' : ['article']
+      'fake_thing',
+      [
+        {entityBundle' : ['article']},
+        {entityBundle' : ['article']}
+      ]
     });
 
     groucho.getActivities({
-      'group' : 'fake_thing',
-      'property' : 'entityBundle',
-      'value' : ['wrong', 'article']
-    });
-
-    groucho.getActivities({
-      'group' : 'fake_thing',
-      'property' : 'entityBundle',
-      'value' : ['wrong']
+      'fake_thing',
+      [
+        {entityBundle' : ['article']},
+        {entityBundle' : ['profile', 'blog']}
+      ]
     });
 */
+
   });
 
   module('Favorites');

--- a/test/groucho_test.js
+++ b/test/groucho_test.js
@@ -84,7 +84,7 @@
   });
 
   test('Pageview activities', function() {
-    var myResults = groucho.getActivities('browsing'),
+    var myResults = groucho.getActivities({'group' : 'browsing'}),
         fakeData = { 'meainingLess': 'info' },
         timeout = 0;
 
@@ -110,7 +110,7 @@
     history.pushState('', 'New Page Title', window.location + '#another-page');
     // Manually create another browsing record.
     groucho.trackHit();
-    myResults = groucho.getActivities('browsing');
+    myResults = groucho.getActivities({'group' : 'browsing'});
     strictEqual(
       myResults.length,
       2,
@@ -127,7 +127,7 @@
       timeout = i * 150;
       stop();
       setTimeout(function () {
-          groucho.createActivity('fake_thing', fakeData);
+        groucho.createActivity('fake_thing', fakeData);
         start();
       }, timeout);
     }
@@ -137,7 +137,7 @@
     setTimeout(function () {
 
       strictEqual(
-        groucho.getActivities('fake_thing').length,
+        groucho.getActivities({'group' : 'fake_thing'}).length,
         groucho.config.trackExtent,
         'Tracking activities are kept within the configured extent'
       );
@@ -158,6 +158,56 @@
 
   });
 
+  //@todo Confirm granular activity request work.
+  test('Activity retrieval', function() {
+
+/*
+
+    groucho.getActivities();
+
+    groucho.getActivities({
+      'group' : 'fake_thing',
+    });
+
+    groucho.getActivities({
+      'group' : 'wrong',
+    });
+
+    groucho.getActivities({
+      'group' : 'fake_thing',
+      'property' : 'entityBundle'
+    });
+
+    groucho.getActivities({
+      'group' : 'fake_thing',
+      'value' : ['article']
+    });
+
+    groucho.getActivities({
+      'group' : 'fake_thing',
+      'property' : 'entityBundle',
+      'value' : 'article'
+    });
+
+    groucho.getActivities({
+      'group' : 'fake_thing',
+      'property' : 'entityBundle',
+      'value' : ['article']
+    });
+
+    groucho.getActivities({
+      'group' : 'fake_thing',
+      'property' : 'entityBundle',
+      'value' : ['wrong', 'article']
+    });
+
+    groucho.getActivities({
+      'group' : 'fake_thing',
+      'property' : 'entityBundle',
+      'value' : ['wrong']
+    });
+*/
+  });
 
   module('Favorites');
 


### PR DESCRIPTION
### Changes:

Allow more fine grained activity lookups...

``` javascript
groucho.getActivities('watch', [
  {'videoType' : ['tutorials']}
]);
```

``` javascript
groucho.getActivities('formSubmit', [
  {'formId' : ['site_search', 'support_search']}
]);
```

``` javascript
groucho.getActivities('browsing', [
  {'entityType' : ['blog', 'visualization']},
  {'category' : ['social-content']},
  {'author' : ['555', '123', '999']},
]);
```
### To Do:
- Tests for all forms of lookup. Branch now down to 71% coverage.
