### PR TITLE
Safe storage retrieval

### DIFF
--- a/dist/groucho.js
+++ b/dist/groucho.js
@@ -173,12 +173,18 @@ var groucho = window.groucho || {};
     }
 
     // Ensure sorting regardless of index.
-    returnVals.sort(function (a, b) {
-      if (parseInt(b._key.split('.')[2], 10) > parseInt(a._key.split('.')[2], 10)) {
-        return -1;
-      }
-      else return 1;
-    });
+    if (group) {
+      // Ensure sorting regardless of index.
+      returnVals.sort(function (a, b) {
+        var timeA = b._key.split('.')[2],
+            timeB = a._key.split('.')[2];
+
+        if (parseInt(timeA, 10) > parseInt(timeB, 10)) {
+          return -1;
+        }
+        else return 1;
+      });
+    }
 
     return returnVals;
   };

--- a/src/groucho.js
+++ b/src/groucho.js
@@ -115,7 +115,7 @@ var groucho = window.groucho || {};
    * @param {string} data
    *   Data to store-- string, int, object.
    */
-  groucho.createActivity = function createActivity(group, data) {
+    groucho.createActivity = function createActivity(group, data) {
     var results = groucho.getActivities(group),
         n = new Date().getTime(),
         diff = 0;
@@ -175,10 +175,17 @@ var groucho = window.groucho || {};
 
     // Ensure sorting regardless of index.
     returnVals.sort(function (a, b) {
+      // Created non-standard or outside Groucho.
+      if (!b.hasOwnProperty('_key')) {
+        return 1;
+      }
+      //
       if (parseInt(b._key.split('.')[2], 10) > parseInt(a._key.split('.')[2], 10)) {
         return -1;
       }
-      else return 1;
+      else {
+        return 1;
+      }
     });
 
     return returnVals;


### PR DESCRIPTION
Avoids JS errors when looking through localStorage items, which were added outside Groucho and don't match the name-spacing pattern.